### PR TITLE
Fix citadel_settings database table and basic theming.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,5 +14,4 @@
  
 @import "normalize";
 @import "bootstrap";
-@import "defaultTheme";
 

--- a/app/assets/stylesheets/secondTheme.scss
+++ b/app/assets/stylesheets/secondTheme.scss
@@ -1,0 +1,11 @@
+.nav{
+    background-color: yellow;
+  
+  }
+  
+  .navbar-right{
+    padding-right:10px;
+    position: relative;
+    padding-top:5px;
+    padding-bottom:5px;
+  }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,8 @@
   <head>
     <title>Citadel</title>
     <%= csrf_meta_tags %>
-    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_link_tag    'application' ,media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_link_tag     Setting.theme ,media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
   <body>

--- a/config/app.yml
+++ b/config/app.yml
@@ -2,6 +2,7 @@
 defaults: &defaults
   db_secret: "swgemus3cr37!"
   salt_length: 12
+  theme: "defaultTheme"
 
 development:
   <<: *defaults

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,3 +12,8 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
+
+Rails.application.config.assets.precompile += %w( defaultTheme.css )
+Rails.application.config.assets.precompile += %w( secondTheme.css )
+
+

--- a/db/migrate/20180512014311_fix_citadel_settings_table.rb
+++ b/db/migrate/20180512014311_fix_citadel_settings_table.rb
@@ -1,0 +1,9 @@
+class FixCitadelSettingsTable < ActiveRecord::Migration[5.1]
+  def up
+    rename_table :settings, :citadel_settings
+  end
+
+  def down
+    rename_table :citadel_settings, :settings
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180503234040) do
+ActiveRecord::Schema.define(version: 20180512014311) do
 
   create_table "account_bans", primary_key: "ban_id", id: :integer, unsigned: true, force: :cascade, options: "ENGINE=MyISAM DEFAULT CHARSET=latin1" do |t|
     t.integer "account_id", null: false, unsigned: true
@@ -76,6 +76,16 @@ ActiveRecord::Schema.define(version: 20180503234040) do
     t.boolean "gender", default: false, null: false
     t.text "template", limit: 255, null: false
     t.timestamp "creation_date", default: -> { "CURRENT_TIMESTAMP" }, null: false
+  end
+
+  create_table "citadel_settings", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+    t.string "var", null: false
+    t.text "value"
+    t.integer "thing_id"
+    t.string "thing_type", limit: 30
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["thing_type", "thing_id", "var"], name: "index_citadel_settings_on_thing_type_and_thing_id_and_var", unique: true
   end
 
   create_table "citadel_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
@@ -608,16 +618,6 @@ ActiveRecord::Schema.define(version: 20180503234040) do
     t.integer "session_id", null: false, unsigned: true
     t.string "ip", limit: 15, null: false
     t.datetime "expires", null: false
-  end
-
-  create_table "settings", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
-    t.string "var", null: false
-    t.text "value"
-    t.integer "thing_id"
-    t.string "thing_type", limit: 30
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["thing_type", "thing_id", "var"], name: "index_settings_on_thing_type_and_thing_id_and_var", unique: true
   end
 
   create_table "skills", primary_key: "skill_id", id: :integer, unsigned: true, force: :cascade, options: "ENGINE=MyISAM DEFAULT CHARSET=latin1" do |t|


### PR DESCRIPTION
This pull request does two things:

1. Fixes the 'citadel_settings' database table. Somehow during the Devise update for registration, it got renamed to 'settings'. This broke the settings form. It has been renamed and all is well.

2. Adds basic theming. You can now switch between Citadel themes by changing it to the desired theme name in the /admin/settings section. The only two themes available at the moment are 'defaultTheme' and 'secondTheme', neither of which are particularly theme-y. This is just a proof of concept that will be expanded at a later time.

To add a new theme, create a new .scss file in the app/assets/stylesheets folder. Then go to config/initializers/assets.rb and copy one of the precompile lines, paste and change the name to your .scss file. You can now change theme by editing the setting in /admin/settings.